### PR TITLE
Properly escape quotes and backslashes on in C extension dumps

### DIFF
--- a/src/pghstore/_speedups.c
+++ b/src/pghstore/_speedups.c
@@ -375,7 +375,7 @@ static PyMethodDef CPgHstoreMethods[] = {
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
-#if PY_MAJOR_VERSION >= 3
+#if IS_PY3
 static int pghstore_speedups_traverse(PyObject *m, visitproc visit, void *arg) {
     Py_VISIT(GETSTATE(m)->error);
     return 0;
@@ -421,7 +421,7 @@ init_speedups(void)
 int
 main(int argc, char *argv[])
 {
-#if PY_MAJOR_VERSION >= 3
+#if IS_PY3
     wchar_t *program = Py_DecodeLocale(argv[0], NULL);
     /* Pass program name to the Python interpreter */
     Py_SetProgramName(program);
@@ -432,7 +432,7 @@ main(int argc, char *argv[])
     /* Initialize the Python interpreter.  Required. */
     Py_Initialize();
 
-#if PY_MAJOR_VERSION < 3
+#if IS_PY2
     /* Add a static module */
     init_speedups();
 #endif

--- a/src/pghstore/_speedups.c
+++ b/src/pghstore/_speedups.c
@@ -7,7 +7,15 @@ struct module_state {
     PyObject *error;
 };
 
-#if PY_MAJOR_VERSION >= 3
+#ifndef IS_PY3
+#define IS_PY3 PY_MAJOR_VERSION == 3
+#endif
+
+#ifndef IS_PY2
+#define IS_PY2 PY_MAJOR_VERSION == 2
+#endif
+
+#if IS_PY3
 #define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
 #endif
 
@@ -66,6 +74,32 @@ unescape(char *copy_from_start, char *copy_from_end, char *encoding, const char 
   free(copy_to);
 
   return unicode;
+}
+
+PyObject *
+escape(PyObject* to_escape)
+{
+    PyObject *intermediately_escaped;
+    PyObject *escaped;
+#if IS_PY3
+    /* We're operating on a bytes object and what the char*s treated as bytes
+     * objects too.
+     */
+    char *build_value_format_string = "yy";
+#else
+    /* We're operating on a str object and what the char*s treated as str
+     * objects too.
+     */
+    char *build_value_format_string = "ss";
+#endif
+
+    intermediately_escaped = PyObject_CallMethod(to_escape, "replace", build_value_format_string, "\\", "\\\\");
+    if (!intermediately_escaped) {
+        return NULL;
+    }
+    escaped = PyObject_CallMethod(intermediately_escaped, "replace", build_value_format_string, "\"", "\\\"");
+    Py_DECREF(intermediately_escaped);
+    return escaped;
 }
 
 static PyObject *
@@ -189,7 +223,9 @@ _speedups_dumps(PyObject *self, PyObject *args, PyObject *keywds)
   Py_INCREF(Py_None);
   PyObject *value_map_callback = Py_None;
   Py_INCREF(Py_None);
-  PyObject *unencoded_key, *key, *unencoded_value, *value, *result;
+  PyObject *unencoded_key, *unescaped_key, *key;
+  PyObject *unencoded_value, *unescaped_value, *value;
+  PyObject *result;
   PyObject *comma, *arrow, *empty, *s_null, *citation;
   PyObject *exception_string = NULL;
   PyObject *exception_string_format_args = NULL;
@@ -245,14 +281,20 @@ _speedups_dumps(PyObject *self, PyObject *args, PyObject *keywds)
     }
 
     if (PyUnicode_Check(unencoded_key)) {
-        key = PyUnicode_AsEncodedString(unencoded_key, encoding, errors);
+        unescaped_key = PyUnicode_AsEncodedString(unencoded_key, encoding, errors);
     } else {
         if (PyBytes_Check(unencoded_key)) {
-            key = unencoded_key;
+            unescaped_key = unencoded_key;
             Py_INCREF(unencoded_key);
         } else {
-            key = PyObject_Bytes(unencoded_key);
+            unescaped_key = PyObject_Bytes(unencoded_key);
         }
+    }
+
+    key = escape(unescaped_key);
+    Py_DECREF(unescaped_key);
+    if (key == NULL) {
+        goto _speedup_dumps_cleanup_and_exit;
     }
 
     unencoded_value = PyTuple_GetItem(item, 1);
@@ -260,10 +302,20 @@ _speedups_dumps(PyObject *self, PyObject *args, PyObject *keywds)
         unencoded_value = PyObject_CallObject(value_map_callback, PyTuple_Pack(1, unencoded_value));
     }
     if (PyUnicode_Check(unencoded_value)) {
-        value = PyUnicode_AsEncodedString(unencoded_value, encoding, errors);
+        unescaped_value = PyUnicode_AsEncodedString(unencoded_value, encoding, errors);
     } else {
-        value = unencoded_value;
+        unescaped_value = unencoded_value;
         Py_INCREF(unencoded_value);
+    }
+
+    if (unescaped_value != Py_None) {
+        value = escape(unescaped_value);
+        Py_DECREF(unescaped_value);
+        if (value == NULL) {
+            goto _speedup_dumps_cleanup_and_exit;
+        }
+    } else {
+        value = unescaped_value;
     }
 
     ConcatOrGotoCleanup(result, key);

--- a/src/pghstore/_speedups.c
+++ b/src/pghstore/_speedups.c
@@ -65,8 +65,8 @@ unescape(char *copy_from_start, char *copy_from_end, char *encoding, const char 
   PyObject *unicode;
 
   for (index = 0; index < (copy_max_length - 1); index++) {
-      if (copy_from_start[index] == '\\' && copy_from_start[index + 1] != '\\') {
-          continue;
+      if (copy_from_start[index] == '\\') {
+          index++;
       }
       copy_to[copy_index++] = copy_from_start[index];
   }

--- a/src/pghstore/_speedups.c
+++ b/src/pghstore/_speedups.c
@@ -124,6 +124,8 @@ _speedups_loads(PyObject *self, PyObject *args, PyObject *keywds)
    * may have embedded null characters.
    * All of our tests presently pass but it's plausible that we could find
    * data with null characters inside and have to update this to match.
+   * We need `s#` as a format argument here so we can receive both unicode and
+   * bytes objects in char *s.
    */
 
   return_value = PyObject_CallObject((PyObject *) return_type, NULL);

--- a/tests/test_dumps.py
+++ b/tests/test_dumps.py
@@ -43,6 +43,11 @@ class DumpsTests(unittest.TestCase):
         self.assertEqual(u'"key_\\"quoted\\"_string"=>"value_\\"quoted\\"_string"',
                          self.pghstore.dumps(d, return_unicode=True))
 
+    def test_escaped_values(self):
+        d = {'key_\\escaped\\_string': 'value_\\escaped\\_string'}
+        self.assertEqual(u'"key_\\\\escaped\\\\_string"=>"value_\\\\escaped\\\\_string"',
+                         self.pghstore.dumps(d, return_unicode=True))
+
     def test_utf8(self):
         d = {"key": "value", "key2": "value2", "key3": None,
              "name": u"Noorwe\xc3\xab", "name2": u"öäå"}

--- a/tests/test_dumps.py
+++ b/tests/test_dumps.py
@@ -48,6 +48,10 @@ class DumpsTests(unittest.TestCase):
         self.assertEqual(u'"key_\\\\escaped\\\\_string"=>"value_\\\\escaped\\\\_string"',
                          self.pghstore.dumps(d, return_unicode=True))
 
+    def test_all_the_escapes(self):
+        d = {"failing": r'some test \"'}
+        self.assertEqual(b'"failing"=>"some test \\\\\\""', self.pghstore.dumps(d))
+
     def test_utf8(self):
         d = {"key": "value", "key2": "value2", "key3": None,
              "name": u"Noorwe\xc3\xab", "name2": u"öäå"}

--- a/tests/test_dumps.py
+++ b/tests/test_dumps.py
@@ -38,6 +38,11 @@ class DumpsTests(unittest.TestCase):
         d = {"key": "value", "key2": "value2", "key3": None}
         self.assertDumpsMatchesDict(self.pghstore.dumps(d, return_unicode=True), d)
 
+    def test_values_with_quotes(self):
+        d = {'key_"quoted"_string': 'value_"quoted"_string'}
+        self.assertEqual(u'"key_\\"quoted\\"_string"=>"value_\\"quoted\\"_string"',
+                         self.pghstore.dumps(d, return_unicode=True))
+
     def test_utf8(self):
         d = {"key": "value", "key2": "value2", "key3": None,
              "name": u"Noorwe\xc3\xab", "name2": u"öäå"}

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -145,6 +145,10 @@ class LoadsTests(unittest.TestCase):
         d = {'key_\\escaped\\_string': 'value_\\escaped\\_string'}
         self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
 
+    def test_load_escape_with_dquote(self):
+        s = r'"failing"=>"some test \\\""'
+        self.assertDictEqual({"failing": 'some test \\"'}, self.pghstore.loads(s))
+
 
 @pytest.mark.skipif(_speedups is None, reason="Could not compile C extensions for tests")
 class LoadsSpeedupsTests(LoadsTests):

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -141,6 +141,10 @@ class LoadsTests(unittest.TestCase):
         d = {'key_"quoted"_string': 'value_"quoted"_string'}
         self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
 
+    def test_round_trip_escaped_characters(self):
+        d = {'key_\\escaped\\_string': 'value_\\escaped\\_string'}
+        self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
+
 
 @pytest.mark.skipif(_speedups is None, reason="Could not compile C extensions for tests")
 class LoadsSpeedupsTests(LoadsTests):

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -137,6 +137,10 @@ class LoadsTests(unittest.TestCase):
         with self.assertRaises(UnicodeDecodeError):
             self.pghstore.loads(s)
 
+    def test_round_trip_double_quotes(self):
+        d = {'key_"quoted"_string': 'value_"quoted"_string'}
+        self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
+
 
 @pytest.mark.skipif(_speedups is None, reason="Could not compile C extensions for tests")
 class LoadsSpeedupsTests(LoadsTests):

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -147,7 +147,11 @@ class LoadsTests(unittest.TestCase):
 
     def test_load_escape_with_dquote(self):
         s = r'"failing"=>"some test \\\""'
-        self.assertDictEqual({"failing": 'some test \\"'}, self.pghstore.loads(s))
+        self.assertDictEqual({"failing": r'some test \"'}, self.pghstore.loads(s))
+
+    def test_roundtrip_with_all_the_escapables(self):
+        d = {"failing": r'some test \"'}
+        self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
 
 
 @pytest.mark.skipif(_speedups is None, reason="Could not compile C extensions for tests")


### PR DESCRIPTION
Our C extension seems to have regressed behaviour for this in our v2.0 of the library.