### PR TITLE
Fix style and lint errors and autoformat with black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pghstore/_speedups.so
 .*.swp
 .cache/
 *.so
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,5 @@ matrix:
       env: TOXENV=pypy3-benchmark
     - python: 3.7
       env: TOXENV=lint
-  allow_failures:
-    - python: 3.7
-      env: TOXENV=lint
 install: pip install tox
 script: tox

--- a/src/pghstore/__init__.py
+++ b/src/pghstore/__init__.py
@@ -1,5 +1,4 @@
-""":mod:`pghstore` --- PostgreSQL hstore formatter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""pghstore provides PostgreSQL hstore formatting for Python.
 
 This small module implements a formatter and a loader for hstore_,
 one of PostgreSQL_ supplied modules, that stores simple key-value pairs.
@@ -41,13 +40,15 @@ except ImportError:
         # XXX required to bootstrap setup.py with no pre-existing six
         pass
 else:
-    def dump(obj, file):
+
+    def dump(obj, file):  # noqa: D103
         file.write(dumps(obj, file))
 
-    def load(file):
+    def load(file):  # noqa: D103
         return loads(file.read())
 
-__all__ = '__version__', 'dump', 'dumps', 'load', 'loads'
+
+__all__ = "__version__", "dump", "dumps", "load", "loads"
 
 
 #: (:class:`six.string_types`) The version string e.g. ``'0.9.2'``.
@@ -55,4 +56,3 @@ __all__ = '__version__', 'dump', 'dumps', 'load', 'loads'
 #: .. deprecated:: 1.0.0
 #:    Use :mod:`pghstore.version` module instead.
 __version__ = VERSION
-

--- a/src/pghstore/_native.py
+++ b/src/pghstore/_native.py
@@ -1,14 +1,17 @@
+"""Native implementation of HStore format in pure Python."""
 from __future__ import print_function
+
+
+import io
 import re
 
 import six
 
-import io
 
-
-def dumps(obj, key_map=None, value_map=None, encoding='utf-8',
-          return_unicode=False):
-    r"""Converts a mapping object as PostgreSQL ``hstore`` format.
+def dumps(
+    obj, key_map=None, value_map=None, encoding="utf-8", return_unicode=False
+):
+    r"""Convert a mapping object as PostgreSQL ``hstore`` format.
 
     .. sourcecode:: pycon
 
@@ -43,7 +46,9 @@ def dumps(obj, key_map=None, value_map=None, encoding='utf-8',
     .. sourcecode:: pycon
 
        >>> import json
-       >>> dumps([('a', list(range(3))), ('b', 2)], value_map=json.dumps) == b'"a"=>"[0, 1, 2]","b"=>"2"'
+       >>> dumps(
+       ...     [('a', list(range(3))), ('b', 2)],
+       ...     value_map=json.dumps) == b'"a"=>"[0, 1, 2]","b"=>"2"'
        True
        >>> import pickle
        >>> result = dumps([('a', list(range(3))), ('b', 2)],
@@ -57,7 +62,10 @@ def dumps(obj, key_map=None, value_map=None, encoding='utf-8',
 
        >>> dumps({u'surname': u'\ud64d'}) == b'"surname"=>"\xed\x99\x8d"'
        True
-       >>> dumps({u'surname': u'\ud64d'}, encoding='utf-32') == b'"\xff\xfe\x00\x00s\x00\x00\x00u\x00\x00\x00r\x00\x00\x00n\x00\x00\x00a\x00\x00\x00m\x00\x00\x00e\x00\x00\x00"=>"\xff\xfe\x00\x00M\xd6\x00\x00"'
+       >>> dumps(
+       ...     {u'surname': u'\ud64d'},
+       ...     encoding='utf-32') == \
+       ... '"\xff\xfe\x00\x00s\x00\x00\x00u\x00\x00\x00r\x00\x00\x00n\x00\x00\x00a\x00\x00\x00m\x00\x00\x00e\x00\x00\x00"=>"\xff\xfe\x00\x00M\xd6\x00\x00"'
        True
 
     If you set ``return_unicode`` to ``True``, it will return :class:`six.text_type`
@@ -80,7 +88,7 @@ def dumps(obj, key_map=None, value_map=None, encoding='utf-8',
     :returns: a ``hstore`` data
     :rtype: :class:`six.string_types`
 
-    """
+    """  # noqa: E501
     b = io.BytesIO()
     dump(obj, b, key_map=key_map, value_map=value_map, encoding=encoding)
     result = b.getvalue()
@@ -89,8 +97,8 @@ def dumps(obj, key_map=None, value_map=None, encoding='utf-8',
     return result
 
 
-def loads(string, encoding='utf-8', return_type=dict):
-    """Parses the passed hstore format ``string`` to a Python mapping object.
+def loads(string, encoding="utf-8", return_type=dict):
+    """Parse the passed hstore format ``string`` to a Python mapping object.
 
     .. sourcecode:: pycon
 
@@ -120,9 +128,8 @@ def loads(string, encoding='utf-8', return_type=dict):
     return return_type(parse(string, encoding=encoding))
 
 
-def dump(obj, file, key_map=None, value_map=None, encoding='utf-8'):
-    """Similar to :func:`dumps()` except it writes the result into the passed
-    ``file`` object instead of returning it.
+def dump(obj, file, key_map=None, value_map=None, encoding="utf-8"):
+    """Write the object to the specified file in HStore format.
 
     .. sourcecode:: pycon
 
@@ -141,35 +148,47 @@ def dump(obj, file, key_map=None, value_map=None, encoding='utf-8'):
     :param encoding: a string encode to use
 
     """
-    if callable(getattr(obj, 'items', None)):
+    if callable(getattr(obj, "items", None)):
         items = obj.items()
-    elif callable(getattr(obj, '__iter__', None)):
+    elif callable(getattr(obj, "__iter__", None)):
         items = iter(obj)
     else:
-        raise TypeError('expected a mapping object, not ' + type(obj).__name__)
+        raise TypeError(
+            "expected a mapping object, not " + type(obj).__name__
+        )
     if key_map is None:
+
         def key_map(key):
-            raise TypeError('key %r is not a string' % key)
+            raise TypeError("key %r is not a string" % key)
+
     elif not callable(key_map):
-        raise TypeError('key_map must be callable')
+        raise TypeError("key_map must be callable")
     elif not (value_map is None or callable(value_map)):
-        raise TypeError('value_map must be callable')
-    write = getattr(file, 'write', None)
+        raise TypeError("value_map must be callable")
+    write = getattr(file, "write", None)
     if not callable(write):
-        raise TypeError('file must be a wrtiable file object that implements '
-                        'write() method')
+        raise TypeError(
+            "file must be a wrtiable file object that implements "
+            "write() method"
+        )
     first = True
     for key, value in items:
-        if not isinstance(key, six.string_types) and not isinstance(key, six.binary_type):
+        if not isinstance(key, six.string_types) and not isinstance(
+            key, six.binary_type
+        ):
             key = key_map(key)
         if not isinstance(key, six.binary_type):
             key = key.encode(encoding)
         if value is None:
             value = None
-        elif not (isinstance(value, six.string_types) or isinstance(value, six.binary_type)):
+        elif not (
+            isinstance(value, six.string_types)
+            or isinstance(value, six.binary_type)
+        ):
             if value_map is None:
-                raise TypeError('value %r of key %r is not a string' %
-                                (value, key))
+                raise TypeError(
+                    "value %r of key %r is not a string" % (value, key)
+                )
             value = value_map(value)
         if value is not None and not isinstance(value, six.binary_type):
             value = value.encode(encoding)
@@ -187,15 +206,14 @@ def dump(obj, file, key_map=None, value_map=None, encoding='utf-8'):
             write(b'"')
 
 
-def load(file, encoding='utf-8'):
-    """Similar to :func:`loads()` except it reads the passed ``file`` object
-    instead of a string.
-
-    """
-    read = getattr(file, 'read', None)
+def load(file, encoding="utf-8"):
+    """Load the contents of file in HStore into a Python object."""
+    read = getattr(file, "read", None)
     if not callable(read):
-        raise TypeError('file must be a readable file object that implements '
-                        'read() method')
+        raise TypeError(
+            "file must be a readable file object that implements "
+            "read() method"
+        )
     return loads(read(), encoding=encoding)
 
 
@@ -215,19 +233,24 @@ def load(file, encoding='utf-8'):
 #:
 #: ``vb``
 #:    Bare value string.
-PAIR_RE = re.compile(r'(?:"(?P<kq>(?:[^\\"]|\\.)*)"|(?P<kb>\S+?))\s*(=>|:)\s*'
-                     r'(?:"(?P<vq>(?:[^\\"]|\\.)*)"|(?P<vn>NULL)|'
-                     r'(?P<vb>[^,]+))(?:,|$)', re.IGNORECASE)
+PAIR_RE = re.compile(
+    r'(?:"(?P<kq>(?:[^\\"]|\\.)*)"|(?P<kb>\S+?))\s*(=>|:)\s*'
+    r'(?:"(?P<vq>(?:[^\\"]|\\.)*)"|(?P<vn>NULL)|'
+    r"(?P<vb>[^,]+))(?:,|$)",
+    re.IGNORECASE,
+)
 
 
-def parse(string, encoding='utf-8'):
-    r"""More primitive function of :func:`loads()`.  It returns a generator
-    that yields pairs of parsed hstore instead of a complete :class:`dict`
-    object.
+def parse(string, encoding="utf-8"):
+    r"""Create a generator of key-value pairs from a string.
+
+    For larger strings or amounts of data, it may be ideal to iterate over the
+    key-value pairs.
 
     .. sourcecode:: pycon
 
-       >>> list(parse('a=>1, b => 2, c => null, d => "NULL"')) == [(u'a', u'1'), (u'b', u'2'), (u'c', None), (u'd', u'NULL')]
+       >>> list(parse('a=>1, b => 2, c => null, d => "NULL"')) == [
+       ...     (u'a', u'1'), (u'b', u'2'), (u'c', None), (u'd', u'NULL')]
        True
        >>> list(parse(r'"a=>1"=>"\"b\"=>2",')) == [(u'a=>1', u'"b"=>2')]
        True
@@ -237,31 +260,31 @@ def parse(string, encoding='utf-8'):
         string = string.decode(encoding)
     offset = 0
     for match in PAIR_RE.finditer(string):
-        if offset > match.start() or string[offset:match.start()].strip():
-            raise ValueError('malformed hstore value: position %d' % offset)
-        kq = match.group('kq')
+        if offset > match.start() or string[offset : match.start()].strip():
+            raise ValueError("malformed hstore value: position %d" % offset)
+        kq = match.group("kq")
         if kq:
             key = unescape(kq)
         else:
-            key = match.group('kb')
-        vq = match.group('vq')
+            key = match.group("kb")
+        vq = match.group("vq")
         if vq:
             value = unescape(vq)
         else:
-            vn = match.group('vn')
-            value = None if vn else match.group('vb')
+            vn = match.group("vn")
+            value = None if vn else match.group("vb")
         yield key, value
         offset = match.end()
     if offset > len(string) or string[offset:].strip():
-        raise ValueError('malformed hstore value: position %d' % offset)
+        raise ValueError("malformed hstore value: position %d" % offset)
 
 
 #: The escape sequence pattern.
-ESCAPE_RE = re.compile(r'\\(.)')
+ESCAPE_RE = re.compile(r"\\(.)")
 
 
 def unescape(s):
-    r"""Strips escaped sequences.
+    r"""Strip escaped sequences.
 
     .. sourcecode:: pycon
 
@@ -271,11 +294,11 @@ def unescape(s):
        '"b"=>2'
 
     """
-    return ESCAPE_RE.sub(r'\1', s)
+    return ESCAPE_RE.sub(r"\1", s)
 
 
 def escape(s):
-    r"""Escapes quotes and backslashes for use in hstore byte strings.
+    r"""Escape quotes and backslashes for use in hstore byte strings.
 
     .. sourcecode:: pycon
 
@@ -283,6 +306,6 @@ def escape(s):
        True
     """
     if isinstance(s, six.binary_type):
-        return s.replace(b'\\', b'\\\\').replace(b'"', b'\\"')
+        return s.replace(b"\\", b"\\\\").replace(b'"', b'\\"')
     else:
-        return s.replace('\\', '\\\\').replace('"', '\\"')
+        return s.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/pghstore/version.py
+++ b/src/pghstore/version.py
@@ -1,5 +1,4 @@
-""":mod:`pghstore.version` --- Version data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""Version data for the pghstore module.
 
 You can find the current version in the command line interface:
 
@@ -11,6 +10,7 @@ You can find the current version in the command line interface:
 .. versionadded:: 1.0.0
 
 """
+
 from __future__ import print_function
 
 __all__ = "VERSION", "VERSION_INFO"

--- a/tests/test_dumps.py
+++ b/tests/test_dumps.py
@@ -1,22 +1,26 @@
 # -*- coding: utf-8 -*-
 import unittest
+
 import pytest
+import six
 
 from pghstore import _native
+
 try:
     from pghstore import _speedups
 except ImportError:
     _speedups = None
 
-import six
-
 
 class DumpsTests(unittest.TestCase):
     pghstore = _native
 
-    def assertDumpsMatchesDict(self, s, d):
-        pairs = [u'"%s"=>%s' % (key, (u'"%s"' % value if value is not None else u"NULL"))
-                 for key, value in six.iteritems(d)]
+    def assertDumpsMatchesDict(self, s, d):  # noqa: N802
+        pairs = [
+            '"%s"=>%s'
+            % (key, ('"%s"' % value if value is not None else "NULL"))
+            for key, value in six.iteritems(d)
+        ]
         for pair in pairs:
             self.assertTrue(pair in s)
         self.assertEqual(len(",".join(pairs)), len(s))
@@ -26,111 +30,133 @@ class DumpsTests(unittest.TestCase):
 
     def test_one(self):
         d = {"key": "value"}
-        self.assertDumpsMatchesDict(self.pghstore.dumps(d, return_unicode=True), d)
+        self.assertDumpsMatchesDict(
+            self.pghstore.dumps(d, return_unicode=True), d
+        )
         d = {"name": "Norge/Noreg"}
-        self.assertDumpsMatchesDict(self.pghstore.dumps(d, return_unicode=True), d)
+        self.assertDumpsMatchesDict(
+            self.pghstore.dumps(d, return_unicode=True), d
+        )
 
     def test_two(self):
         d = {"key": "value", "key2": "value2"}
-        self.assertDumpsMatchesDict(self.pghstore.dumps(d, return_unicode=True), d)
+        self.assertDumpsMatchesDict(
+            self.pghstore.dumps(d, return_unicode=True), d
+        )
 
     def test_null(self):
         d = {"key": "value", "key2": "value2", "key3": None}
-        self.assertDumpsMatchesDict(self.pghstore.dumps(d, return_unicode=True), d)
+        self.assertDumpsMatchesDict(
+            self.pghstore.dumps(d, return_unicode=True), d
+        )
 
     def test_values_with_quotes(self):
         d = {'key_"quoted"_string': 'value_"quoted"_string'}
-        self.assertEqual(u'"key_\\"quoted\\"_string"=>"value_\\"quoted\\"_string"',
-                         self.pghstore.dumps(d, return_unicode=True))
+        self.assertEqual(
+            '"key_\\"quoted\\"_string"=>"value_\\"quoted\\"_string"',
+            self.pghstore.dumps(d, return_unicode=True),
+        )
 
     def test_escaped_values(self):
-        d = {'key_\\escaped\\_string': 'value_\\escaped\\_string'}
-        self.assertEqual(u'"key_\\\\escaped\\\\_string"=>"value_\\\\escaped\\\\_string"',
-                         self.pghstore.dumps(d, return_unicode=True))
+        d = {"key_\\escaped\\_string": "value_\\escaped\\_string"}
+        self.assertEqual(
+            '"key_\\\\escaped\\\\_string"=>"value_\\\\escaped\\\\_string"',
+            self.pghstore.dumps(d, return_unicode=True),
+        )
 
     def test_all_the_escapes(self):
-        d = {"failing": r'some test \"'}
-        self.assertEqual(b'"failing"=>"some test \\\\\\""', self.pghstore.dumps(d))
+        d = {"failing": r"some test \""}
+        self.assertEqual(
+            b'"failing"=>"some test \\\\\\""', self.pghstore.dumps(d)
+        )
 
     def test_utf8(self):
-        d = {"key": "value", "key2": "value2", "key3": None,
-             "name": u"Noorwe\xc3\xab", "name2": u"öäå"}
-        self.assertDumpsMatchesDict(self.pghstore.dumps(d, return_unicode=True), d)
+        d = {
+            "key": "value",
+            "key2": "value2",
+            "key3": None,
+            "name": "Noorwe\xc3\xab",
+            "name2": "öäå",
+        }
+        self.assertDumpsMatchesDict(
+            self.pghstore.dumps(d, return_unicode=True), d
+        )
 
     def test_large(self):
         d = {
-            'name': 'Norge/Noreg',
-            'name:af': u'Noorwe\xeb',
-            'name:ar': u'\u0627\u0644\u0646\u0631\u0648\u064a\u062c',
-            'name:be': u'\u041d\u0430\u0440\u0432\u0435\u0433\u0456\u044f',
-            'name:br': 'Norvegia',
-            'name:ca': 'Noruega',
-            'name:cs': 'Norsko',
-            'name:cy': 'Norwy',
-            'name:da': 'Norge',
-            'name:de': 'Norwegen',
-            'name:el': u'\u039d\u03bf\u03c1\u03b2\u03b7\u03b3\u03af\u03b1',
-            'name:en': 'Norway',
-            'name:eo': 'Norvegio',
-            'name:es': 'Noruega',
-            'name:et': 'Norra',
-            'name:fa': u'\u0646\u0631\u0648\u0698',
-            'name:fi': 'Norja',
-            'name:fo': 'Noregur',
-            'name:fr': u'Norv\xe8ge',
-            'name:fy': 'Noarwegen',
-            'name:ga': 'An Iorua',
-            'name:gd': 'Nirribhidh',
-            'name:haw': 'Nolewai',
-            'name:he': u'\u05e0\u05d5\u05e8\u05d5\u05d5\u05d2\u05d9\u05d4',
-            'name:hr': u'Norve\u0161ka',
-            'name:hu': u'Norv\xe9gia',
-            'name:hy': u'\u0546\u0578\u0580\u057e\u0565\u0563\u056b\u0561',
-            'name:id': 'Norwegia',
-            'name:is': 'Noregur',
-            'name:it': 'Norvegia',
-            'name:ja': u'\u30ce\u30eb\u30a6\u30a7\u30fc',
-            'name:la': 'Norvegia',
-            'name:lb': 'Norwegen',
-            'name:li': 'Noorwege',
-            'name:lt': 'Norvegija',
-            'name:lv': u'Norv\u0113\u0123ija',
-            'name:mn': u'\u041d\u043e\u0440\u0432\u0435\u0433\u0438',
-            'name:nb': 'Norge',
-            'name:nl': 'Noorwegen',
-            'name:nn': 'Noreg',
-            'name:no': 'Norge',
-            'name:pl': 'Norwegia',
-            'name:ru': u'\u041d\u043e\u0440\u0432\u0435\u0433\u0438\u044f',
-            'name:sk': u'N\xf3rsko',
-            'name:sl': u'Norve\u0161ka',
-            'name:sv': 'Norge',
-            'name:th':
-                 u'\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e40\u0e27\u0e22\u0e4c',
-            'name:tr': u'Norve\xe7',
-            'name:uk': u'\u041d\u043e\u0440\u0432\u0435\u0433\u0456\u044f',
-            'name:vi': 'Na Uy',
-            'name:zh': u'\u632a\u5a01',
-            'name:zh_py': 'Nuowei',
-            'name:zh_pyt': u'Nu\xf3w\u0113i',
-            'official_name': 'Kongeriket Norge',
-            'official_name:be':
-                u'\u041a\u0430\u0440\u0430\u043b\u0435\u045e\u0441\u0442\u0432\u0430 \u041d\u0430\u0440\u0432\u0435\u0433\u0456\u044f',
-            'official_name:el':
-                u'\u0392\u03b1\u03c3\u03af\u03bb\u03b5\u03b9\u03bf \u03c4\u03b7\u03c2 \u039d\u03bf\u03c1\u03b2\u03b7\u03b3\u03af\u03b1\u03c2',
-            'official_name:en': 'Kingdom of Norway',
-            'official_name:id': 'Kerajaan Norwegia',
-            'official_name:it': 'Regno di Norvegia',
-            'official_name:ja': u'\u30ce\u30eb\u30a6\u30a7\u30fc\u738b\u56fd',
-            'official_name:lb': u'Kinneksr\xe4ich Norwegen',
-            'official_name:lt': u'Norvegijos Karalyst\u0117',
-            'official_name:sk': u'N\xf3rske kr\xe1\u013eovstvo',
-            'official_name:sv': u'Konungariket Norge',
-            'official_name:vi': u'V\u01b0\u01a1ng qu\u1ed1c Na Uy',
+            "name": "Norge/Noreg",
+            "name:af": "Noorwe\xeb",
+            "name:ar": "\u0627\u0644\u0646\u0631\u0648\u064a\u062c",
+            "name:be": "\u041d\u0430\u0440\u0432\u0435\u0433\u0456\u044f",
+            "name:br": "Norvegia",
+            "name:ca": "Noruega",
+            "name:cs": "Norsko",
+            "name:cy": "Norwy",
+            "name:da": "Norge",
+            "name:de": "Norwegen",
+            "name:el": "\u039d\u03bf\u03c1\u03b2\u03b7\u03b3\u03af\u03b1",
+            "name:en": "Norway",
+            "name:eo": "Norvegio",
+            "name:es": "Noruega",
+            "name:et": "Norra",
+            "name:fa": "\u0646\u0631\u0648\u0698",
+            "name:fi": "Norja",
+            "name:fo": "Noregur",
+            "name:fr": "Norv\xe8ge",
+            "name:fy": "Noarwegen",
+            "name:ga": "An Iorua",
+            "name:gd": "Nirribhidh",
+            "name:haw": "Nolewai",
+            "name:he": "\u05e0\u05d5\u05e8\u05d5\u05d5\u05d2\u05d9\u05d4",
+            "name:hr": "Norve\u0161ka",
+            "name:hu": "Norv\xe9gia",
+            "name:hy": "\u0546\u0578\u0580\u057e\u0565\u0563\u056b\u0561",
+            "name:id": "Norwegia",
+            "name:is": "Noregur",
+            "name:it": "Norvegia",
+            "name:ja": "\u30ce\u30eb\u30a6\u30a7\u30fc",
+            "name:la": "Norvegia",
+            "name:lb": "Norwegen",
+            "name:li": "Noorwege",
+            "name:lt": "Norvegija",
+            "name:lv": "Norv\u0113\u0123ija",
+            "name:mn": "\u041d\u043e\u0440\u0432\u0435\u0433\u0438",
+            "name:nb": "Norge",
+            "name:nl": "Noorwegen",
+            "name:nn": "Noreg",
+            "name:no": "Norge",
+            "name:pl": "Norwegia",
+            "name:ru": "\u041d\u043e\u0440\u0432\u0435\u0433\u0438\u044f",
+            "name:sk": "N\xf3rsko",
+            "name:sl": "Norve\u0161ka",
+            "name:sv": "Norge",
+            "name:th": "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e40\u0e27\u0e22\u0e4c",  # noqa: E501
+            "name:tr": "Norve\xe7",
+            "name:uk": "\u041d\u043e\u0440\u0432\u0435\u0433\u0456\u044f",
+            "name:vi": "Na Uy",
+            "name:zh": "\u632a\u5a01",
+            "name:zh_py": "Nuowei",
+            "name:zh_pyt": "Nu\xf3w\u0113i",
+            "official_name": "Kongeriket Norge",
+            "official_name:be": "\u041a\u0430\u0440\u0430\u043b\u0435\u045e\u0441\u0442\u0432\u0430 \u041d\u0430\u0440\u0432\u0435\u0433\u0456\u044f",  # noqa: E501
+            "official_name:el": "\u0392\u03b1\u03c3\u03af\u03bb\u03b5\u03b9\u03bf \u03c4\u03b7\u03c2 \u039d\u03bf\u03c1\u03b2\u03b7\u03b3\u03af\u03b1\u03c2",  # noqa: E501
+            "official_name:en": "Kingdom of Norway",
+            "official_name:id": "Kerajaan Norwegia",
+            "official_name:it": "Regno di Norvegia",
+            "official_name:ja": "\u30ce\u30eb\u30a6\u30a7\u30fc\u738b\u56fd",
+            "official_name:lb": "Kinneksr\xe4ich Norwegen",
+            "official_name:lt": "Norvegijos Karalyst\u0117",
+            "official_name:sk": "N\xf3rske kr\xe1\u013eovstvo",
+            "official_name:sv": "Konungariket Norge",
+            "official_name:vi": "V\u01b0\u01a1ng qu\u1ed1c Na Uy",
         }
-        self.assertDumpsMatchesDict(self.pghstore.dumps(d, return_unicode=True), d)
+        self.assertDumpsMatchesDict(
+            self.pghstore.dumps(d, return_unicode=True), d
+        )
 
 
-@pytest.mark.skipif(_speedups is None, reason="Could not compile C extensions for tests")
+@pytest.mark.skipif(
+    _speedups is None, reason="Could not compile C extensions for tests"
+)
 class DumpsSpeedupsTests(DumpsTests):
     pghstore = _speedups

--- a/tests/test_loads.py
+++ b/tests/test_loads.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import unittest
+
 import pytest
 
 from pghstore import _native
+
 try:
     from pghstore import _speedups
 except ImportError:
@@ -13,119 +15,198 @@ class LoadsTests(unittest.TestCase):
     pghstore = _native
 
     def test_empty(self):
-        self.assertEqual(self.pghstore.loads(''), {})
+        self.assertEqual(self.pghstore.loads(""), {})
 
     def test_simple(self):
-        self.assertEqual(self.pghstore.loads('"key" => "value"'), {"key": "value"})
+        self.assertEqual(
+            self.pghstore.loads('"key" => "value"'), {"key": "value"}
+        )
 
         self.assertEqual(
             self.pghstore.loads('"key" => "value", "key2" => "value2"'),
-            {"key": "value", "key2": "value2"})
+            {"key": "value", "key2": "value2"},
+        )
 
     def test_escaped_double_quote(self):
         self.assertEqual(
-            self.pghstore.loads(r'"k\"ey" => "va\"lue"'), {'k"ey': 'va"lue'})
+            self.pghstore.loads(r'"k\"ey" => "va\"lue"'), {'k"ey': 'va"lue'}
+        )
 
     def test_null(self):
         self.assertEqual(self.pghstore.loads('"key" => null'), {"key": None})
         self.assertEqual(self.pghstore.loads('"key" => NULL'), {"key": None})
-        self.assertEqual(self.pghstore.loads(
-                '"key" => NULL, "key2": "value2"'), {"key": None, "key2": "value2"})
-        self.assertEqual(self.pghstore.loads(
-                b'"key0" => "value0", "key" => NULL, "key2": "value2"'),
-                        {"key0": "value0", "key": None, "key2": "value2"})
+        self.assertEqual(
+            self.pghstore.loads('"key" => NULL, "key2": "value2"'),
+            {"key": None, "key2": "value2"},
+        )
+        self.assertEqual(
+            self.pghstore.loads(
+                b'"key0" => "value0", "key" => NULL, "key2": "value2"'
+            ),
+            {"key0": "value0", "key": None, "key2": "value2"},
+        )
 
     def test_utf8(self):
         self.maxDiff = None
         # self.assertEqual(self.pghstore.loads('"åäö" => "åäö"'), {"åäö": "åäö"})
-        s = u'"name"=>"Noorwe\xeb", "name2"=>"öäå"'.encode('utf-8')
-        self.assertEqual(self.pghstore.loads(s),
-                         {"name": b"Noorwe\xc3\xab".decode('utf-8'),
-                          "name2": u"öäå"})
-        names = b'"name"=>"Norge/Noreg", "name:af"=>"Noorwe\xc3\xab", "name:ar"=>"\xd8\xa7\xd9\x84\xd9\x86\xd8\xb1\xd9\x88\xd9\x8a\xd8\xac", "name:be"=>"\xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f", "name:br"=>"Norvegia", "name:ca"=>"Noruega", "name:cs"=>"Norsko", "name:cy"=>"Norwy", "name:da"=>"Norge", "name:de"=>"Norwegen", "name:el"=>"\xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1", "name:en"=>"Norway", "name:eo"=>"Norvegio", "name:es"=>"Noruega", "name:et"=>"Norra", "name:fa"=>"\xd9\x86\xd8\xb1\xd9\x88\xda\x98", "name:fi"=>"Norja", "name:fo"=>"Noregur", "name:fr"=>"Norv\xc3\xa8ge", "name:fy"=>"Noarwegen", "name:ga"=>"An Iorua", "name:gd"=>"Nirribhidh", "name:he"=>"\xd7\xa0\xd7\x95\xd7\xa8\xd7\x95\xd7\x95\xd7\x92\xd7\x99\xd7\x94", "name:hr"=>"Norve\xc5\xa1ka", "name:hu"=>"Norv\xc3\xa9gia", "name:hy"=>"\xd5\x86\xd5\xb8\xd6\x80\xd5\xbe\xd5\xa5\xd5\xa3\xd5\xab\xd5\xa1", "name:id"=>"Norwegia", "name:is"=>"Noregur", "name:it"=>"Norvegia", "name:ja"=>"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc", "name:la"=>"Norvegia", "name:lb"=>"Norwegen", "name:li"=>"Noorwege", "name:lt"=>"Norvegija", "name:lv"=>"Norv\xc4\x93\xc4\xa3ija", "name:mn"=>"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8", "name:nb"=>"Norge", "name:nl"=>"Noorwegen", "name:nn"=>"Noreg", "name:no"=>"Norge", "name:pl"=>"Norwegia", "name:ru"=>"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8\xd1\x8f", "name:sk"=>"N\xc3\xb3rsko", "name:sl"=>"Norve\xc5\xa1ka", "name:sv"=>"Norge", "name:th"=>"\xe0\xb8\x9b\xe0\xb8\xa3\xe0\xb8\xb0\xe0\xb9\x80\xe0\xb8\x97\xe0\xb8\xa8\xe0\xb8\x99\xe0\xb8\xad\xe0\xb8\xa3\xe0\xb9\x8c\xe0\xb9\x80\xe0\xb8\xa7\xe0\xb8\xa2\xe0\xb9\x8c", "name:tr"=>"Norve\xc3\xa7", "name:uk"=>"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f", "name:vi"=>"Na Uy", "name:zh"=>"\xe6\x8c\xaa\xe5\xa8\x81", "name:haw"=>"Nolewai", "name:zh_py"=>"Nuowei", "name:zh_pyt"=>"Nu\xc3\xb3w\xc4\x93i", "official_name"=>"Kongeriket Norge", "official_name:be"=>"\xd0\x9a\xd0\xb0\xd1\x80\xd0\xb0\xd0\xbb\xd0\xb5\xd1\x9e\xd1\x81\xd1\x82\xd0\xb2\xd0\xb0 \xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f", "official_name:el"=>"\xce\x92\xce\xb1\xcf\x83\xce\xaf\xce\xbb\xce\xb5\xce\xb9\xce\xbf \xcf\x84\xce\xb7\xcf\x82 \xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1\xcf\x82", "official_name:en"=>"Kingdom of Norway", "official_name:id"=>"Kerajaan Norwegia", "official_name:it"=>"Regno di Norvegia", "official_name:ja"=>"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc\xe7\x8e\x8b\xe5\x9b\xbd", "official_name:lb"=>"Kinneksr\xc3\xa4ich Norwegen", "official_name:lt"=>"Norvegijos Karalyst\xc4\x97", "official_name:sk"=>"N\xc3\xb3rske kr\xc3\xa1\xc4\xbeovstvo", "official_name:sv"=>"Konungariket Norge", "official_name:vi"=>"V\xc6\xb0\xc6\xa1ng qu\xe1\xbb\x91c Na Uy"'
+        s = '"name"=>"Noorwe\xeb", "name2"=>"öäå"'.encode("utf-8")
+        self.assertEqual(
+            self.pghstore.loads(s),
+            {"name": b"Noorwe\xc3\xab".decode("utf-8"), "name2": "öäå"},
+        )
+        names = b'"name"=>"Norge/Noreg", "name:af"=>"Noorwe\xc3\xab", "name:ar"=>"\xd8\xa7\xd9\x84\xd9\x86\xd8\xb1\xd9\x88\xd9\x8a\xd8\xac", "name:be"=>"\xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f", "name:br"=>"Norvegia", "name:ca"=>"Noruega", "name:cs"=>"Norsko", "name:cy"=>"Norwy", "name:da"=>"Norge", "name:de"=>"Norwegen", "name:el"=>"\xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1", "name:en"=>"Norway", "name:eo"=>"Norvegio", "name:es"=>"Noruega", "name:et"=>"Norra", "name:fa"=>"\xd9\x86\xd8\xb1\xd9\x88\xda\x98", "name:fi"=>"Norja", "name:fo"=>"Noregur", "name:fr"=>"Norv\xc3\xa8ge", "name:fy"=>"Noarwegen", "name:ga"=>"An Iorua", "name:gd"=>"Nirribhidh", "name:he"=>"\xd7\xa0\xd7\x95\xd7\xa8\xd7\x95\xd7\x95\xd7\x92\xd7\x99\xd7\x94", "name:hr"=>"Norve\xc5\xa1ka", "name:hu"=>"Norv\xc3\xa9gia", "name:hy"=>"\xd5\x86\xd5\xb8\xd6\x80\xd5\xbe\xd5\xa5\xd5\xa3\xd5\xab\xd5\xa1", "name:id"=>"Norwegia", "name:is"=>"Noregur", "name:it"=>"Norvegia", "name:ja"=>"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc", "name:la"=>"Norvegia", "name:lb"=>"Norwegen", "name:li"=>"Noorwege", "name:lt"=>"Norvegija", "name:lv"=>"Norv\xc4\x93\xc4\xa3ija", "name:mn"=>"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8", "name:nb"=>"Norge", "name:nl"=>"Noorwegen", "name:nn"=>"Noreg", "name:no"=>"Norge", "name:pl"=>"Norwegia", "name:ru"=>"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8\xd1\x8f", "name:sk"=>"N\xc3\xb3rsko", "name:sl"=>"Norve\xc5\xa1ka", "name:sv"=>"Norge", "name:th"=>"\xe0\xb8\x9b\xe0\xb8\xa3\xe0\xb8\xb0\xe0\xb9\x80\xe0\xb8\x97\xe0\xb8\xa8\xe0\xb8\x99\xe0\xb8\xad\xe0\xb8\xa3\xe0\xb9\x8c\xe0\xb9\x80\xe0\xb8\xa7\xe0\xb8\xa2\xe0\xb9\x8c", "name:tr"=>"Norve\xc3\xa7", "name:uk"=>"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f", "name:vi"=>"Na Uy", "name:zh"=>"\xe6\x8c\xaa\xe5\xa8\x81", "name:haw"=>"Nolewai", "name:zh_py"=>"Nuowei", "name:zh_pyt"=>"Nu\xc3\xb3w\xc4\x93i", "official_name"=>"Kongeriket Norge", "official_name:be"=>"\xd0\x9a\xd0\xb0\xd1\x80\xd0\xb0\xd0\xbb\xd0\xb5\xd1\x9e\xd1\x81\xd1\x82\xd0\xb2\xd0\xb0 \xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f", "official_name:el"=>"\xce\x92\xce\xb1\xcf\x83\xce\xaf\xce\xbb\xce\xb5\xce\xb9\xce\xbf \xcf\x84\xce\xb7\xcf\x82 \xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1\xcf\x82", "official_name:en"=>"Kingdom of Norway", "official_name:id"=>"Kerajaan Norwegia", "official_name:it"=>"Regno di Norvegia", "official_name:ja"=>"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc\xe7\x8e\x8b\xe5\x9b\xbd", "official_name:lb"=>"Kinneksr\xc3\xa4ich Norwegen", "official_name:lt"=>"Norvegijos Karalyst\xc4\x97", "official_name:sk"=>"N\xc3\xb3rske kr\xc3\xa1\xc4\xbeovstvo", "official_name:sv"=>"Konungariket Norge", "official_name:vi"=>"V\xc6\xb0\xc6\xa1ng qu\xe1\xbb\x91c Na Uy"'  # noqa: E501
         self.assertListEqual(
             self.pghstore.loads(names, return_type=list),
             [
-                (u"name", u"Norge/Noreg"),
-                (u"name:af", b"Noorwe\xc3\xab".decode('utf-8')),
-                (u"name:ar",
-                    b"\xd8\xa7\xd9\x84\xd9\x86\xd8\xb1\xd9\x88\xd9\x8a\xd8\xac".decode('utf-8')),
-                (u"name:be",
-                    b"\xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f".decode('utf-8')),
-                (u"name:br", u"Norvegia"),
-                (u"name:ca", u"Noruega"),
-                (u"name:cs", u"Norsko"),
-                (u"name:cy", u"Norwy"),
-                (u"name:da", u"Norge"),
-                (u"name:de", u"Norwegen"),
-                (u"name:el",
-                    b"\xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1".decode('utf-8')),
-                (u"name:en", u"Norway"),
-                (u"name:eo", u"Norvegio"),
-                (u"name:es", u"Noruega"),
-                (u"name:et", u"Norra"),
-                (u"name:fa", b"\xd9\x86\xd8\xb1\xd9\x88\xda\x98".decode('utf-8')),
-                (u"name:fi", u"Norja"),
-                (u"name:fo", u"Noregur"),
-                (u"name:fr", b"Norv\xc3\xa8ge".decode('utf-8')),
-                (u"name:fy", u"Noarwegen"),
-                (u"name:ga", u"An Iorua"),
-                (u"name:gd", u"Nirribhidh"),
-                (u"name:he",
-                    b"\xd7\xa0\xd7\x95\xd7\xa8\xd7\x95\xd7\x95\xd7\x92\xd7\x99\xd7\x94".decode('utf-8')),
-                (u"name:hr", b"Norve\xc5\xa1ka".decode('utf-8')),
-                (u"name:hu", b"Norv\xc3\xa9gia".decode('utf-8')),
-                (u"name:hy",
-                    b"\xd5\x86\xd5\xb8\xd6\x80\xd5\xbe\xd5\xa5\xd5\xa3\xd5\xab\xd5\xa1".decode('utf-8')),
-                (u"name:id", u"Norwegia"),
-                (u"name:is", u"Noregur"),
-                (u"name:it", u"Norvegia"),
-                (u"name:ja",
-                    b"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc".decode('utf-8')),
-                (u"name:la", u"Norvegia"),
-                (u"name:lb", u"Norwegen"),
-                (u"name:li", u"Noorwege"),
-                (u"name:lt", u"Norvegija"),
-                (u"name:lv", b"Norv\xc4\x93\xc4\xa3ija".decode('utf-8')),
-                (u"name:mn",
-                    b"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8".decode('utf-8')),
-                (u"name:nb", u"Norge"),
-                (u"name:nl", u"Noorwegen"),
-                (u"name:nn", u"Noreg"),
-                (u"name:no", u"Norge"),
-                (u"name:pl", u"Norwegia"),
-                (u"name:ru",
-                    b"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8\xd1\x8f".decode('utf-8')),
-                (u"name:sk", b"N\xc3\xb3rsko".decode('utf-8')),
-                (u"name:sl", b"Norve\xc5\xa1ka".decode('utf-8')),
-                (u"name:sv", u"Norge"),
-                (u"name:th",
-                    b"\xe0\xb8\x9b\xe0\xb8\xa3\xe0\xb8\xb0\xe0\xb9\x80\xe0\xb8\x97\xe0\xb8\xa8\xe0\xb8\x99\xe0\xb8\xad\xe0\xb8\xa3\xe0\xb9\x8c\xe0\xb9\x80\xe0\xb8\xa7\xe0\xb8\xa2\xe0\xb9\x8c".decode('utf-8')),
-                (u"name:tr", b"Norve\xc3\xa7".decode('utf-8')),
-                (u"name:uk",
-                    b"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f".decode('utf-8')),
-                (u"name:vi", u"Na Uy"),
-                (u"name:zh", b"\xe6\x8c\xaa\xe5\xa8\x81".decode('utf-8')),
-                (u"name:haw", u"Nolewai"),
-                (u"name:zh_py", u"Nuowei"),
-                (u"name:zh_pyt", b"Nu\xc3\xb3w\xc4\x93i".decode('utf-8')),
-                (u"official_name", u"Kongeriket Norge"),
-                (u"official_name:be",
-                    b"\xd0\x9a\xd0\xb0\xd1\x80\xd0\xb0\xd0\xbb\xd0\xb5\xd1\x9e\xd1\x81\xd1\x82\xd0\xb2\xd0\xb0 \xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f".decode('utf-8')),
-
-                (u"official_name:el",
-                    b"\xce\x92\xce\xb1\xcf\x83\xce\xaf\xce\xbb\xce\xb5\xce\xb9\xce\xbf \xcf\x84\xce\xb7\xcf\x82 \xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1\xcf\x82".decode('utf-8')),
-                (u"official_name:en", u"Kingdom of Norway"),
-                (u"official_name:id", u"Kerajaan Norwegia"),
-                (u"official_name:it", u"Regno di Norvegia"),
-                (u"official_name:ja",
-                    b"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc\xe7\x8e\x8b\xe5\x9b\xbd".decode('utf-8')),
-                (u"official_name:lb", b"Kinneksr\xc3\xa4ich Norwegen".decode('utf-8')),
-                (u"official_name:lt", b"Norvegijos Karalyst\xc4\x97".decode('utf-8')),
-                (u"official_name:sk", b"N\xc3\xb3rske kr\xc3\xa1\xc4\xbeovstvo".decode('utf-8')),
-                (u"official_name:sv", u"Konungariket Norge"),
-                (u"official_name:vi", b"V\xc6\xb0\xc6\xa1ng qu\xe1\xbb\x91c Na Uy".decode('utf-8')),
-            ])
+                ("name", "Norge/Noreg"),
+                ("name:af", b"Noorwe\xc3\xab".decode("utf-8")),
+                (
+                    "name:ar",
+                    b"\xd8\xa7\xd9\x84\xd9\x86\xd8\xb1\xd9\x88\xd9\x8a\xd8\xac".decode(
+                        "utf-8"
+                    ),
+                ),
+                (
+                    "name:be",
+                    b"\xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:br", "Norvegia"),
+                ("name:ca", "Noruega"),
+                ("name:cs", "Norsko"),
+                ("name:cy", "Norwy"),
+                ("name:da", "Norge"),
+                ("name:de", "Norwegen"),
+                (
+                    "name:el",
+                    b"\xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:en", "Norway"),
+                ("name:eo", "Norvegio"),
+                ("name:es", "Noruega"),
+                ("name:et", "Norra"),
+                (
+                    "name:fa",
+                    b"\xd9\x86\xd8\xb1\xd9\x88\xda\x98".decode("utf-8"),
+                ),
+                ("name:fi", "Norja"),
+                ("name:fo", "Noregur"),
+                ("name:fr", b"Norv\xc3\xa8ge".decode("utf-8")),
+                ("name:fy", "Noarwegen"),
+                ("name:ga", "An Iorua"),
+                ("name:gd", "Nirribhidh"),
+                (
+                    "name:he",
+                    b"\xd7\xa0\xd7\x95\xd7\xa8\xd7\x95\xd7\x95\xd7\x92\xd7\x99\xd7\x94".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:hr", b"Norve\xc5\xa1ka".decode("utf-8")),
+                ("name:hu", b"Norv\xc3\xa9gia".decode("utf-8")),
+                (
+                    "name:hy",
+                    b"\xd5\x86\xd5\xb8\xd6\x80\xd5\xbe\xd5\xa5\xd5\xa3\xd5\xab\xd5\xa1".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:id", "Norwegia"),
+                ("name:is", "Noregur"),
+                ("name:it", "Norvegia"),
+                (
+                    "name:ja",
+                    b"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:la", "Norvegia"),
+                ("name:lb", "Norwegen"),
+                ("name:li", "Noorwege"),
+                ("name:lt", "Norvegija"),
+                ("name:lv", b"Norv\xc4\x93\xc4\xa3ija".decode("utf-8")),
+                (
+                    "name:mn",
+                    b"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:nb", "Norge"),
+                ("name:nl", "Noorwegen"),
+                ("name:nn", "Noreg"),
+                ("name:no", "Norge"),
+                ("name:pl", "Norwegia"),
+                (
+                    "name:ru",
+                    b"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd0\xb8\xd1\x8f".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:sk", b"N\xc3\xb3rsko".decode("utf-8")),
+                ("name:sl", b"Norve\xc5\xa1ka".decode("utf-8")),
+                ("name:sv", "Norge"),
+                (
+                    "name:th",
+                    b"\xe0\xb8\x9b\xe0\xb8\xa3\xe0\xb8\xb0\xe0\xb9\x80\xe0\xb8\x97\xe0\xb8\xa8\xe0\xb8\x99\xe0\xb8\xad\xe0\xb8\xa3\xe0\xb9\x8c\xe0\xb9\x80\xe0\xb8\xa7\xe0\xb8\xa2\xe0\xb9\x8c".decode(  # noqa: E501
+                        "utf-8"
+                    ),
+                ),
+                ("name:tr", b"Norve\xc3\xa7".decode("utf-8")),
+                (
+                    "name:uk",
+                    b"\xd0\x9d\xd0\xbe\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f".decode(
+                        "utf-8"
+                    ),
+                ),
+                ("name:vi", "Na Uy"),
+                ("name:zh", b"\xe6\x8c\xaa\xe5\xa8\x81".decode("utf-8")),
+                ("name:haw", "Nolewai"),
+                ("name:zh_py", "Nuowei"),
+                ("name:zh_pyt", b"Nu\xc3\xb3w\xc4\x93i".decode("utf-8")),
+                ("official_name", "Kongeriket Norge"),
+                (
+                    "official_name:be",
+                    b"\xd0\x9a\xd0\xb0\xd1\x80\xd0\xb0\xd0\xbb\xd0\xb5\xd1\x9e\xd1\x81\xd1\x82\xd0\xb2\xd0\xb0 \xd0\x9d\xd0\xb0\xd1\x80\xd0\xb2\xd0\xb5\xd0\xb3\xd1\x96\xd1\x8f".decode(  # noqa: E501
+                        "utf-8"
+                    ),
+                ),
+                (
+                    "official_name:el",
+                    b"\xce\x92\xce\xb1\xcf\x83\xce\xaf\xce\xbb\xce\xb5\xce\xb9\xce\xbf \xcf\x84\xce\xb7\xcf\x82 \xce\x9d\xce\xbf\xcf\x81\xce\xb2\xce\xb7\xce\xb3\xce\xaf\xce\xb1\xcf\x82".decode(  # noqa: E501
+                        "utf-8"
+                    ),
+                ),
+                ("official_name:en", "Kingdom of Norway"),
+                ("official_name:id", "Kerajaan Norwegia"),
+                ("official_name:it", "Regno di Norvegia"),
+                (
+                    "official_name:ja",
+                    b"\xe3\x83\x8e\xe3\x83\xab\xe3\x82\xa6\xe3\x82\xa7\xe3\x83\xbc\xe7\x8e\x8b\xe5\x9b\xbd".decode(  # noqa: E501
+                        "utf-8"
+                    ),
+                ),
+                (
+                    "official_name:lb",
+                    b"Kinneksr\xc3\xa4ich Norwegen".decode("utf-8"),
+                ),
+                (
+                    "official_name:lt",
+                    b"Norvegijos Karalyst\xc4\x97".decode("utf-8"),
+                ),
+                (
+                    "official_name:sk",
+                    b"N\xc3\xb3rske kr\xc3\xa1\xc4\xbeovstvo".decode("utf-8"),
+                ),
+                ("official_name:sv", "Konungariket Norge"),
+                (
+                    "official_name:vi",
+                    b"V\xc6\xb0\xc6\xa1ng qu\xe1\xbb\x91c Na Uy".decode(
+                        "utf-8"
+                    ),
+                ),
+            ],
+        )
 
     def test_decode_failure_key(self):
         s = b'"\x01\xb6\xc3\xa4\xc3\xa5"=>"123"'
@@ -142,18 +223,22 @@ class LoadsTests(unittest.TestCase):
         self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
 
     def test_round_trip_escaped_characters(self):
-        d = {'key_\\escaped\\_string': 'value_\\escaped\\_string'}
+        d = {"key_\\escaped\\_string": "value_\\escaped\\_string"}
         self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
 
     def test_load_escape_with_dquote(self):
         s = r'"failing"=>"some test \\\""'
-        self.assertDictEqual({"failing": r'some test \"'}, self.pghstore.loads(s))
+        self.assertDictEqual(
+            {"failing": r"some test \""}, self.pghstore.loads(s)
+        )
 
     def test_roundtrip_with_all_the_escapables(self):
-        d = {"failing": r'some test \"'}
+        d = {"failing": r"some test \""}
         self.assertDictEqual(d, self.pghstore.loads(self.pghstore.dumps(d)))
 
 
-@pytest.mark.skipif(_speedups is None, reason="Could not compile C extensions for tests")
+@pytest.mark.skipif(
+    _speedups is None, reason="Could not compile C extensions for tests"
+)
 class LoadsSpeedupsTests(LoadsTests):
     pghstore = _speedups

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ deps =
 commands =
     black -l 78 {env:BLACK_ARGS:} --target-version py36 --safe src/pghstore tests/
     flake8 src/pghstore tests
-    pylint src/pghstore tests
-    mypy src/pghstore
+    -pylint src/pghstore tests
+    -mypy src/pghstore
     bandit -r src/pghstore
     python setup.py check -r -s
 
@@ -75,6 +75,9 @@ exclude =
     *.egg-info,
     .cache,
     .eggs
+per-file-ignores =
+    src/pghstore/_native.py:C901,
+    tests/*.py:D,
 max-complexity = 10
 import-order-style = google
 application-import-names = pghstore


### PR DESCRIPTION
This introduces linting and static analysis to the project and enforces
it as part of continuous integration.

Note: For now, we're allowing mypy and pylint to fail in `tox` but we'll
address those eventually and they can be nice beginner-friendly work
items.