### PR TITLE
Build source distributions only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     wheel
     setuptools
 commands =
-    python setup.py -q sdist bdist_wheel
+    python setup.py -q sdist
 
 [testenv:release]
 basepython = python3


### PR DESCRIPTION
When we release, we shouldn't be building wheels since we can't build
universal wheels for upload. If we want to build wheels that are
pre-compiled against CPython versions, we'll need to do that with Travis
CI or some other CI/CD distributor and give them the ability to publish
to PyPI for us.

For now, let's stick to source distributions only.